### PR TITLE
fix: shiki singleton warning

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -60,17 +60,18 @@ export const multiThemeDefaults: Required<CommonOptions & MultiThemesOptions> =
     defaultColor: false,
   };
 
+// Singleton
+let shikiPromise: Promise<Highlighter> | null = null;
+
 function createPlugin(options: Required<Options>): Plugin {
   /**
-   * Load highlighter only once
+   * Create/Load highlighter only once
    */
-  let highlighter: Highlighter | undefined = undefined;
   const loadHighlighter = () => {
-    if (highlighter) return highlighter;
-    return createHighlighter(options.highlighter).then((h) => {
-      highlighter = h;
-      return h;
-    });
+    if (!shikiPromise) {
+      shikiPromise = createHighlighter(options.highlighter);
+    }
+    return shikiPromise;
   };
 
   /**
@@ -89,14 +90,14 @@ function createPlugin(options: Required<Options>): Plugin {
     const highlighter = await loadHighlighter();
     const sources = document.querySelectorAll("pre code[class*=language-]");
     for (const sourceCode of sources) {
-      if (!sourceCode.textContent) return;
+      if (!sourceCode.textContent) continue;
 
       const sourcePre = sourceCode.parentElement;
       const className = sourceCode.getAttribute("class");
-      if (!className || !sourcePre) return;
+      if (!className || !sourcePre) continue;
 
       const match = className.match(/language-(.+)/);
-      if (!match) return;
+      if (!match) continue;
 
       const [, lang] = match;
 


### PR DESCRIPTION
Thank you for making this plugin! It's been incredible useful for me.

I've been getting shiki singleton warning like this:

```console
$ deno task build
Task build deno task lume
Task lume echo "import 'lume/cli.ts'" | deno run -A -
Loading config file file:///Users/ysun/Workspace/ysun/_config.ts
[Shiki] 10 instances have been created. Shiki is supposed to be used as a singleton, consider refactoring your code to cache your highlighter instance; Or call `highlighter.dispose()` to release unused instances.
[Shiki] 20 instances have been created. Shiki is supposed to be used as a singleton, consider refactoring your code to cache your highlighter instance; Or call `highlighter.dispose()` to release unused instances.
[Shiki] 30 instances have been created. Shiki is supposed to be used as a singleton, consider refactoring your code to cache your highlighter instance; Or call `highlighter.dispose()` to release unused instances.
[Shiki] 40 instances have been created. Shiki is supposed to be used as a singleton, consider refactoring your code to cache your highlighter instance; Or call `highlighter.dispose()` to release unused instances.
...
```

I believe creating a global variable is the only solution here...

Also, for the query selector: if nothing is found, it should continue to the next iteration instead of bail out directly